### PR TITLE
fix: edit forms wrongly enforce code format on unchanged codes

### DIFF
--- a/weightapp/forms.py
+++ b/weightapp/forms.py
@@ -501,13 +501,17 @@ class BaseStoneTypeForm(forms.ModelForm):
         id = cleaned_data.get('base_stone_type_id')
         hoen = has_only_en(id)
 
-        spc = SetPatternCode.objects.get(m_name = 'BaseStoneType')
-        fm = str(spc.end) + spc.pattern
+        original_id = self.instance.pk
+        code_unchanged = original_id is not None and id and id.upper().replace(" ", "") == original_id
 
-        if not hoen: #เช็คตัวอักษรภาษาไทยในรหัส
-            raise forms.ValidationError(u"รหัสหินผิด ("+ str(id) +") มีตัวอักษรภาษาไทยหรือช่องว่าง ไม่สามารถบันทึกได้ กรุณาใส่รหัสใหม่")
-        elif not id or len(id) != len(fm) or not id.endswith(spc.pattern):
-            raise forms.ValidationError(u"รหัสควรมี  format '"+ fm +"' กรุณาเปลี่ยนรหัสใหม่.")
+        if not code_unchanged:
+            spc = SetPatternCode.objects.get(m_name = 'BaseStoneType')
+            fm = str(spc.end) + spc.pattern
+
+            if not hoen: #เช็คตัวอักษรภาษาไทยในรหัส
+                raise forms.ValidationError(u"รหัสหินผิด ("+ str(id) +") มีตัวอักษรภาษาไทยหรือช่องว่าง ไม่สามารถบันทึกได้ กรุณาใส่รหัสใหม่")
+            elif not id or len(id) != len(fm) or not id.endswith(spc.pattern):
+                raise forms.ValidationError(u"รหัสควรมี  format '"+ fm +"' กรุณาเปลี่ยนรหัสใหม่.")
         return cleaned_data
     
     def save(self, commit=True):
@@ -543,13 +547,17 @@ class BaseScoopForm(forms.ModelForm):
         id = cleaned_data.get('scoop_id')
         hoen = has_only_en(id)
 
-        spc = SetPatternCode.objects.get(m_name = 'BaseScoop')
-        fm = str(spc.end) + spc.pattern
+        original_id = self.instance.pk
+        code_unchanged = original_id is not None and id and id.upper().replace(" ", "") == original_id
 
-        if not hoen: #เช็คตัวอักษรภาษาไทยในรหัส
-            raise forms.ValidationError(u"รหัสผู้ตักผิด ("+ str(id) +") มีตัวอักษรภาษาไทยหรือช่องว่าง ไม่สามารถบันทึกได้ กรุณาใส่รหัสใหม่")
-        elif not id or len(id) != len(fm) or not id.endswith(spc.pattern):
-            raise forms.ValidationError(u"รหัสควรมี  format '"+ fm +"' กรุณาเปลี่ยนรหัสใหม่.")
+        if not code_unchanged:
+            spc = SetPatternCode.objects.get(m_name = 'BaseScoop')
+            fm = str(spc.end) + spc.pattern
+
+            if not hoen: #เช็คตัวอักษรภาษาไทยในรหัส
+                raise forms.ValidationError(u"รหัสผู้ตักผิด ("+ str(id) +") มีตัวอักษรภาษาไทยหรือช่องว่าง ไม่สามารถบันทึกได้ กรุณาใส่รหัสใหม่")
+            elif not id or len(id) != len(fm) or not id.endswith(spc.pattern):
+                raise forms.ValidationError(u"รหัสควรมี  format '"+ fm +"' กรุณาเปลี่ยนรหัสใหม่.")
         return cleaned_data
 
     def save(self, commit=True):
@@ -583,14 +591,19 @@ class BaseCarTeamForm(forms.ModelForm):
         cleaned_data = self.cleaned_data
         #id รxx
         id = cleaned_data.get('car_team_id')
-        spc = SetPatternCode.objects.get(m_name = 'BaseCarTeam')
-        fm =  spc.pattern + str(spc.end)
         #oil_id 92-V-xxx
         oil_id = cleaned_data.get('oil_customer_id')
         pattern = re.compile(r'^92-V-\d{3}$')
 
-        if not id or len(id) != len(fm) or not id.startswith(spc.pattern):
-            raise forms.ValidationError(u"รหัสควรมี  format '"+ fm +"' กรุณาเปลี่ยนรหัสใหม่.")
+        original_id = self.instance.pk
+        code_unchanged = original_id is not None and id and id.replace(" ", "") == original_id
+
+        if not code_unchanged:
+            spc = SetPatternCode.objects.get(m_name = 'BaseCarTeam')
+            fm =  spc.pattern + str(spc.end)
+
+            if not id or len(id) != len(fm) or not id.startswith(spc.pattern):
+                raise forms.ValidationError(u"รหัสควรมี  format '"+ fm +"' กรุณาเปลี่ยนรหัสใหม่.")
         ''' ปิดรหัสลูกค้าน้ำมัน 10/06/2569
         if not oil_id or not pattern.match(oil_id):
             raise forms.ValidationError(u"รหัสลูกค้าน้ำมันควรมี  format '92-V-xxx' กรุณาเปลี่ยนรหัสใหม่.")        
@@ -630,11 +643,15 @@ class BaseCarForm(forms.ModelForm):
         bct = cleaned_data.get('base_car_team')
         id = cleaned_data.get('car_id')
 
-        spc = SetPatternCode.objects.get(m_name = 'BaseCar')
-        fm =  str(bct.car_team_id) + spc.pattern + str(spc.end)
+        original_id = self.instance.pk
+        code_unchanged = original_id is not None and id and id.upper().replace(" ", "") == original_id
 
-        if not id or len(id) != len(fm) or not id.startswith(bct.car_team_id):
-            raise forms.ValidationError(u"รหัสควรมี  format '"+ fm +"' กรุณาเปลี่ยนรหัสใหม่.")
+        if not code_unchanged and bct:
+            spc = SetPatternCode.objects.get(m_name = 'BaseCar')
+            fm =  str(bct.car_team_id) + spc.pattern + str(spc.end)
+
+            if not id or len(id) != len(fm) or not id.startswith(bct.car_team_id):
+                raise forms.ValidationError(u"รหัสควรมี  format '"+ fm +"' กรุณาเปลี่ยนรหัสใหม่.")
         return cleaned_data
 
     def save(self, commit=True):
@@ -778,13 +795,17 @@ class BaseDriverForm(forms.ModelForm):
         id = cleaned_data.get('driver_id')
         hoen = has_only_en(id)
 
-        spc = SetPatternCode.objects.get(m_name = 'BaseDriver')
-        fm = str(spc.end) + spc.pattern
+        original_id = self.instance.pk
+        code_unchanged = original_id is not None and id and id.upper().replace(" ", "") == original_id
 
-        if not hoen: #เช็คตัวอักษรภาษาไทยในรหัส
-            raise forms.ValidationError(u"รหัสผู้ขับผิด ("+ str(id) +") มีตัวอักษรภาษาไทยหรือช่องว่าง ไม่สามารถบันทึกได้ กรุณาใส่รหัสใหม่")
-        elif not id or len(id) != len(fm) or not id.endswith(spc.pattern):
-            raise forms.ValidationError(u"รหัสควรมี  format '"+ fm +"' กรุณาเปลี่ยนรหัสใหม่.")
+        if not code_unchanged:
+            spc = SetPatternCode.objects.get(m_name = 'BaseDriver')
+            fm = str(spc.end) + spc.pattern
+
+            if not hoen: #เช็คตัวอักษรภาษาไทยในรหัส
+                raise forms.ValidationError(u"รหัสผู้ขับผิด ("+ str(id) +") มีตัวอักษรภาษาไทยหรือช่องว่าง ไม่สามารถบันทึกได้ กรุณาใส่รหัสใหม่")
+            elif not id or len(id) != len(fm) or not id.endswith(spc.pattern):
+                raise forms.ValidationError(u"รหัสควรมี  format '"+ fm +"' กรุณาเปลี่ยนรหัสใหม่.")
         return cleaned_data
 
     def save(self, commit=True):

--- a/weightapp/views.py
+++ b/weightapp/views.py
@@ -5089,16 +5089,21 @@ def editBaseStoneType(request, id):
  
     form = BaseStoneTypeForm(request.POST or None, instance = obj)
     if form.is_valid():
-        try:
-            stone_type_form = form.save()
-
-            # update weight ด้วย
-            weights = Weight.objects.filter(stone_type_id = stone_type_form.pk)
-            weights.update(stone_type_name = stone_type_form.base_stone_type_name)#iiiiiiiiii
-        except IntegrityError:
-            form.add_error(None, 'มีชื่อนี้อยู่แล้ว กรุณาตั้งชื่อใหม่.')
+        new_id = form.cleaned_data.get('base_stone_type_id').upper().replace(" ", "")
+        duplicate = new_id != id and BaseStoneType.objects.filter(base_stone_type_id = new_id).exclude(pk = id).exists()
+        if duplicate:
+            form.add_error(None, 'มีรหัสนี้อยู่แล้ว กรุณาเปลี่ยนรหัสใหม่.')
         else:
-            return redirect('settingBaseStoneType')
+            try:
+                stone_type_form = form.save()
+
+                # update weight ด้วย
+                weights = Weight.objects.filter(stone_type_id = stone_type_form.pk)
+                weights.update(stone_type_name = stone_type_form.base_stone_type_name)#iiiiiiiiii
+            except IntegrityError:
+                form.add_error(None, 'มีชื่อนี้อยู่แล้ว กรุณาตั้งชื่อใหม่.')
+            else:
+                return redirect('settingBaseStoneType')
 
     context = {
         'form':form,
@@ -5176,16 +5181,21 @@ def editBaseScoop(request, id):
  
     form = BaseScoopForm(request.POST or None, instance = obj)
     if form.is_valid():
-        try:
-            scoop_form = form.save()
-
-            # update weight ด้วย
-            weights = Weight.objects.filter(scoop_id = scoop_form.pk)
-            weights.update(scoop_name = scoop_form.scoop_name)#iiiiiiiiii
-        except IntegrityError:
-            form.add_error(None, 'มีชื่อนี้อยู่แล้ว กรุณาตั้งชื่อใหม่.')
+        new_id = form.cleaned_data.get('scoop_id').upper().replace(" ", "")
+        duplicate = new_id != id and BaseScoop.objects.filter(scoop_id = new_id).exclude(pk = id).exists()
+        if duplicate:
+            form.add_error(None, 'มีรหัสนี้อยู่แล้ว กรุณาเปลี่ยนรหัสใหม่.')
         else:
-            return redirect('settingBaseScoop')
+            try:
+                scoop_form = form.save()
+
+                # update weight ด้วย
+                weights = Weight.objects.filter(scoop_id = scoop_form.pk)
+                weights.update(scoop_name = scoop_form.scoop_name)#iiiiiiiiii
+            except IntegrityError:
+                form.add_error(None, 'มีชื่อนี้อยู่แล้ว กรุณาตั้งชื่อใหม่.')
+            else:
+                return redirect('settingBaseScoop')
 
     context = {
         'form':form,
@@ -5264,16 +5274,21 @@ def editBaseCarTeam(request, id):
  
     form = BaseCarTeamForm(request.POST or None, instance = obj)
     if form.is_valid():
-        try:
-            car_team_form = form.save()
-
-            # update weight ด้วย
-            weights = Weight.objects.filter(car_team_id = car_team_form.pk)
-            weights.update(car_team_name = car_team_form.car_team_name)#iiiiiiiiii
-        except IntegrityError:
-            form.add_error(None, 'มีรหัสลูกค้าน้ำมัน หรือมีชื่อทีมนี้อยู่แล้ว กรุณาเปลี่ยนรหัสลูกค้าน้ำมันหรือชื่อทีมใหม่.')
+        new_id = form.cleaned_data.get('car_team_id').replace(" ", "")
+        duplicate = new_id != id and BaseCarTeam.objects.filter(car_team_id = new_id).exclude(pk = id).exists()
+        if duplicate:
+            form.add_error(None, 'มีรหัสนี้อยู่แล้ว กรุณาเปลี่ยนรหัสใหม่.')
         else:
-            return redirect('settingBaseCarTeam')
+            try:
+                car_team_form = form.save()
+
+                # update weight ด้วย
+                weights = Weight.objects.filter(car_team_id = car_team_form.pk)
+                weights.update(car_team_name = car_team_form.car_team_name)#iiiiiiiiii
+            except IntegrityError:
+                form.add_error(None, 'มีรหัสลูกค้าน้ำมัน หรือมีชื่อทีมนี้อยู่แล้ว กรุณาเปลี่ยนรหัสลูกค้าน้ำมันหรือชื่อทีมใหม่.')
+            else:
+                return redirect('settingBaseCarTeam')
 
     context = {
         'form':form,
@@ -5351,18 +5366,23 @@ def editBaseCar(request, id):
  
     form = BaseCarForm(request.POST or None, instance = obj)
     if form.is_valid():
-        try:
-            car_form = form.save()
-
-            '''
-            # update weight ด้วย
-            weights = Weight.objects.filter(scoop_id = scoop_form.pk)
-            weights.update(scoop_name = scoop_form.scoop_name)         
-            '''
-        except IntegrityError:
-            form.add_error(None, 'มีชื่อนี้อยู่แล้ว กรุณาตั้งชื่อใหม่.')
+        new_id = form.cleaned_data.get('car_id').upper().replace(" ", "")
+        duplicate = new_id != id and BaseCar.objects.filter(car_id = new_id).exclude(pk = id).exists()
+        if duplicate:
+            form.add_error(None, 'มีรหัสนี้อยู่แล้ว กรุณาเปลี่ยนรหัสใหม่.')
         else:
-            return redirect('settingBaseCar')
+            try:
+                car_form = form.save()
+
+                '''
+                # update weight ด้วย
+                weights = Weight.objects.filter(scoop_id = scoop_form.pk)
+                weights.update(scoop_name = scoop_form.scoop_name)
+                '''
+            except IntegrityError:
+                form.add_error(None, 'มีชื่อนี้อยู่แล้ว กรุณาตั้งชื่อใหม่.')
+            else:
+                return redirect('settingBaseCar')
 
     context = {
         'form':form,
@@ -5616,16 +5636,21 @@ def editBaseDriver(request, id):
  
     form = BaseDriverForm(request.POST or None, instance = obj)
     if form.is_valid():
-        try:
-            driver_form = form.save()
-
-            # update weight ด้วย
-            weights = Weight.objects.filter(driver_id = driver_form.pk)
-            weights.update(driver_name = driver_form.driver_name)#iiiiiiiiii
-        except IntegrityError:
-            form.add_error(None, 'มีชื่อนี้อยู่แล้ว กรุณาตั้งชื่อใหม่.')
+        new_id = form.cleaned_data.get('driver_id').upper().replace(" ", "")
+        duplicate = new_id != id and BaseDriver.objects.filter(driver_id = new_id).exclude(pk = id).exists()
+        if duplicate:
+            form.add_error(None, 'มีรหัสนี้อยู่แล้ว กรุณาเปลี่ยนรหัสใหม่.')
         else:
-            return redirect('settingBaseDriver')
+            try:
+                driver_form = form.save()
+
+                # update weight ด้วย
+                weights = Weight.objects.filter(driver_id = driver_form.pk)
+                weights.update(driver_name = driver_form.driver_name)#iiiiiiiiii
+            except IntegrityError:
+                form.add_error(None, 'มีชื่อนี้อยู่แล้ว กรุณาตั้งชื่อใหม่.')
+            else:
+                return redirect('settingBaseDriver')
         
     context = {
         'form':form,


### PR DESCRIPTION
## Summary
- Skip code-format validation on edit when the code is unchanged, in `BaseStoneTypeForm`, `BaseScoopForm`, `BaseCarTeamForm`, `BaseCarForm`, `BaseDriverForm` — fixes the false-positive `รหัสควรมี format xxx กรุณาเปลี่ยนรหัสใหม่.` error shown when saving an existing valid record.
- Create behavior and its format/duplicate validation are unchanged.
- Add explicit duplicate-code checks in the corresponding `editBase*` views (excluding the current record), since Django's default PK-uniqueness check can miss duplicates when a `CharField` primary key value changes.

## Test plan
- [ ] Create valid code in each of the 5 modules → saves successfully
- [ ] Create invalid code in each module → shows format error
- [ ] Edit existing record without changing code → saves successfully
- [ ] Edit existing record, change to another valid unused code → saves successfully
- [ ] Edit existing record, change to invalid format → shows format error
- [ ] Edit existing record, change to a code already used by another record → shows duplicate error, does not save