### PR TITLE
แก้ไข admin AppRelease: ผู้สร้าง (created_by) ตั้งค่าเริ่มต้นเป็นผู้ใช้ที่ login

### DIFF
--- a/weightapp/admin.py
+++ b/weightapp/admin.py
@@ -603,6 +603,12 @@ class AppReleaseAdmin(admin.ModelAdmin):
     list_display = ('product_code', 'version', 'channel', 'is_mandatory', 'is_active', 'has_sql_script', 'released_at')
     list_filter = ('product_code', 'channel', 'is_active')
     ordering = ('-released_at',)
+    exclude = ('created_by',)
+
+    def save_model(self, request, obj, form, change):
+        if not change or not obj.created_by_id:
+            obj.created_by = request.user
+        super().save_model(request, obj, form, change)
 
     def has_sql_script(self, obj):
         return bool(obj.sql_script)


### PR DESCRIPTION
## Summary
- ซ่อนฟิลด์ `created_by` ใน AppReleaseAdmin และตั้งค่าอัตโนมัติเป็น user ที่ login อยู่เมื่อสร้าง record ใหม่

## Test plan
- [x] `python manage.py test` — 14 tests passed