### PR TITLE
แก้ไข setting ตัวเลือกบริษัทเป็น code + name

### DIFF
--- a/weightapp/filters.py
+++ b/weightapp/filters.py
@@ -4,8 +4,14 @@ from django.forms.widgets import DateInput, TextInput
 import django_filters
 from django_filters import DateFilter
 from .models import Weight, BaseWeightType, BaseWeightStation, BaseVatType, BaseMill, BaseLineType, Production, StoneEstimate, BaseStoneType, BaseScoop, BaseCarTeam, BaseCar, BaseSite, BaseCustomer, BaseDriver, BaseCarRegistration, BaseJobType, BaseCustomerSite, Stock, User, UserScale, GasPrice, PortStock, PortStockStone, PortStockStoneItem, LoadingRate, LoadingRateLoc, LoadingRateItem
+from .forms import CompanyCodeNameChoiceField
+from django_filters.fields import ModelChoiceField as DFModelChoiceField
 from django.utils.translation import gettext_lazy as _
 from datetime import date
+
+class CompanyCodeNameFilterChoiceField(DFModelChoiceField):
+    #แสดง "รหัส - ชื่อ" ในตัวเลือก company ของฟิลเตอร์ แต่ค่าที่ใช้กรองยังเป็น id เดิม
+    label_from_instance = CompanyCodeNameChoiceField.label_from_instance
 
 class WeightFilter(django_filters.FilterSet):
     start_created = django_filters.DateFilter(field_name = "date", lookup_expr='gte', widget=DateInput(attrs={'type':'date'}))
@@ -140,6 +146,8 @@ class BaseScoopFilter(django_filters.FilterSet):
 BaseScoopFilter.base_filters['scoop_id'].label = 'รหัสผู้ตัก'
 BaseScoopFilter.base_filters['scoop_name'].label = 'ชื่อผู้ตัก'
 BaseScoopFilter.base_filters['company'].label = 'บริษัท'
+BaseScoopFilter.base_filters['company'].field_class = CompanyCodeNameFilterChoiceField
+BaseScoopFilter.base_filters['company'].queryset = BaseScoopFilter.base_filters['company'].queryset.exclude(code='ALL')
 
 
 class BaseCarTeamFilter(django_filters.FilterSet):
@@ -214,6 +222,8 @@ class BaseDriverFilter(django_filters.FilterSet):
 BaseDriverFilter.base_filters['driver_id'].label = 'รหัสผู้ขับ'
 BaseDriverFilter.base_filters['driver_name'].label = 'ชื่อผู้ขับ'
 BaseDriverFilter.base_filters['company'].label = 'บริษัท'
+BaseDriverFilter.base_filters['company'].field_class = CompanyCodeNameFilterChoiceField
+BaseDriverFilter.base_filters['company'].queryset = BaseDriverFilter.base_filters['company'].queryset.exclude(code='ALL')
 
 class BaseCarRegistrationFilter(django_filters.FilterSet):
     จีน = 'จีน'
@@ -236,6 +246,8 @@ BaseCarRegistrationFilter.base_filters['car_registration_id'].label = 'รหั
 BaseCarRegistrationFilter.base_filters['car_registration_name'].label = 'ชื่อทะเบียนรถ'
 BaseCarRegistrationFilter.base_filters['car_type'].label = 'ประเภทรถ'
 BaseCarRegistrationFilter.base_filters['company'].label = 'บริษัท'
+BaseCarRegistrationFilter.base_filters['company'].field_class = CompanyCodeNameFilterChoiceField
+BaseCarRegistrationFilter.base_filters['company'].queryset = BaseCarRegistrationFilter.base_filters['company'].queryset.exclude(code='ALL')
 
 
 class GasPriceFilter(django_filters.FilterSet):

--- a/weightapp/forms.py
+++ b/weightapp/forms.py
@@ -20,7 +20,16 @@ import re
 from django_select2 import forms as s2forms
 from django_select2.forms import ModelSelect2Widget
 
-#new check error id 
+class CompanyCodeNameChoiceField(forms.ModelChoiceField):
+    #แสดง "รหัส - ชื่อ" ในตัวเลือก company แต่ค่าที่บันทึกยังเป็น id เดิม
+    def label_from_instance(self, obj):
+        code = (obj.code or '').strip()
+        name = (obj.name or '').strip()
+        if code and name:
+            return f"{code} - {name}"
+        return code or name or str(obj.pk)
+
+#new check error id
 def has_only_en(name):
     char_set = string.ascii_letters + string.digits + "-"
     return all((True if x in char_set else False for x in name))
@@ -536,6 +545,16 @@ class BaseScoopForm(forms.ModelForm):
             'company': _('บริษัท'),
        }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        old_field = self.fields['company']
+        self.fields['company'] = CompanyCodeNameChoiceField(
+            queryset = old_field.queryset.exclude(code='ALL'),
+            label = old_field.label,
+            required = old_field.required,
+            widget = old_field.widget,
+        )
+
     def clean_name_field(self):
         name_field = self.cleaned_data.get('scoop_name')
         if name_field:
@@ -784,6 +803,16 @@ class BaseDriverForm(forms.ModelForm):
             'company': _('บริษัท'),
         }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        old_field = self.fields['company']
+        self.fields['company'] = CompanyCodeNameChoiceField(
+            queryset = old_field.queryset.exclude(code='ALL'),
+            label = old_field.label,
+            required = old_field.required,
+            widget = old_field.widget,
+        )
+
     def clean_name_field(self):
         name_field = self.cleaned_data.get('driver_name')
         if name_field:
@@ -839,6 +868,16 @@ class BaseCarRegistrationForm(forms.ModelForm):
             'car_type': _('ประเภทรถ'),
             'company': _('บริษัท'),
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        old_field = self.fields['company']
+        self.fields['company'] = CompanyCodeNameChoiceField(
+            queryset = old_field.queryset.exclude(code='ALL'),
+            label = old_field.label,
+            required = old_field.required,
+            widget = old_field.widget,
+        )
 
     def clean_name_field(self):
         name_field = self.cleaned_data.get('car_registration_name')

--- a/weightapp/templates/manage/baseCarRegistration.html
+++ b/weightapp/templates/manage/baseCarRegistration.html
@@ -88,7 +88,7 @@ href="{% static 'extensions/datatables.net-bs5/css/dataTables.bootstrap5.min.css
                     <td><b>{% if is_edit_setting %}<a href="{% url 'editBaseCarRegistration' i.car_registration_id %}">{{i.car_registration_id}}</a>{% else %}{{i.car_registration_id}}{%endif%}</b></td>
                     <td>{{i.car_registration_name}}</td>
                     <td>{{i.car_type}}</td>
-                    <td>{{i.company}}</td>
+                    <td>{{i.company.code}}{% if i.company.code and i.company.name %} - {% endif %}{{i.company.name}}</td>
                   </tr>
                   {% empty %}
                   <tr>

--- a/weightapp/templates/manage/baseDriver.html
+++ b/weightapp/templates/manage/baseDriver.html
@@ -83,7 +83,7 @@ href="{% static 'extensions/datatables.net-bs5/css/dataTables.bootstrap5.min.css
                   <tr>
                     <td><b>{% if is_edit_setting %}<a href="{% url 'editBaseDriver' i.driver_id %}">{{i.driver_id}}</a>{% else %}{{i.driver_id}}{%endif%}</b></td>
                     <td>{{i.driver_name}}</td>
-                    <td>{{i.company}}</td>
+                    <td>{{i.company.code}}{% if i.company.code and i.company.name %} - {% endif %}{{i.company.name}}</td>
                   </tr>
                   {% empty %}
                   <tr>

--- a/weightapp/templates/manage/baseScoop.html
+++ b/weightapp/templates/manage/baseScoop.html
@@ -83,7 +83,7 @@ href="{% static 'extensions/datatables.net-bs5/css/dataTables.bootstrap5.min.css
                   <tr>
                     <td><b>{% if is_edit_setting %}<a href="{% url 'editBaseScoop' i.scoop_id %}">{{i.scoop_id}}</a>{% else %}{{i.scoop_id}}{%endif%}</b></td>
                     <td>{{i.scoop_name}}</td>
-                    <td>{{i.company}}</td>
+                    <td>{{i.company.code}}{% if i.company.code and i.company.name %} - {% endif %}{{i.company.name}}</td>
                   </tr>
                   {% empty %}
                   <tr>


### PR DESCRIPTION
## Summary
- Company选择 dropdowns (scoop, driver, car registration filters/forms) now display "code - name" instead of just name, while the stored value stays the record id.
- Excludes the 'ALL' company code from these choice lists.

## Test plan
- [x] `python manage.py test` — 14/14 passing